### PR TITLE
use un-gopkg'd log15

### DIFF
--- a/axiom.go
+++ b/axiom.go
@@ -51,12 +51,12 @@ import (
 	"sort"
 
 	"github.com/codegangsta/cli"
+	log "github.com/inconshreveable/log15"
+	"github.com/inconshreveable/log15/term"
 	"github.com/inconshreveable/mousetrap"
 	"github.com/mattn/go-colorable"
-	"gopkg.in/inconshreveable/go-update.v0"
+	update "gopkg.in/inconshreveable/go-update.v0"
 	"gopkg.in/inconshreveable/go-update.v0/check"
-	log "gopkg.in/inconshreveable/log15.v2"
-	"gopkg.in/inconshreveable/log15.v2/term"
 	"gopkg.in/yaml.v1"
 )
 


### PR DESCRIPTION
Switching this from the gopkg.in version to github.com/inconshreveable/log15.

This doesn't build with codegangsta/cli master but you can work around it by
checking out cli version c31a7975863e7810c92e2e288a9ab074f9a88f29.
